### PR TITLE
Temporarily exclude Windows from build matrix.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
             ghc: 8.10.7
           - os: windows-latest
             ghc: 9.0.2
+          - os: windows-latest
+            ghc: 9.2.2
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR temporarily disables the Windows build.

It seems as though the Windows build might be failing because at least one of the generated paths is too long:

```
realgcc.exe: error: D:\\a\\quickcheck-classes-semigroup\\quickcheck-classes-semigroup\\dist-newstyle\\build\\x86_64-windows\\ghc-9.2.2\\quickcheck-classes-semigroup-0.0.0\\t\\quickcheck-classes-semigroup-test\\build\\quickcheck-classes-semigroup-test\\quickcheck-classes-semigroup-test-tmp\Main.o: No such file or directory
```